### PR TITLE
Specified bear gender to align with seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Your columns should be the following types:
 |id     |integer| <-- Make sure this is the table's primary key
 |name   |text   |
 |age    |integer|
-|gender |text   |(The choices could be "Male", "Female", "Other", or "Prefer not to say")|
+|gender |text   | <-- Should be a single, capitalized letter: 'M' or 'F'
 |color  |text   |
-|temperament|text|
+|temperament | text|
 |alive  |boolean|
 
 Read about [SQLite3 Datatypes](https://www.sqlite.org/datatype3.html) to determine what your insert values are going to be. Be sure to pay attention to how booleans are expressed in SQLite3.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Read about [SQLite3 Datatypes](https://www.sqlite.org/datatype3.html) to determi
 
 ## Part 2: `INSERT`
 
-Get the tests in `spec/insert_spec.rb` to pass. Input the following 8 bears (you can make up details about them):
+Get the tests in `spec/insert_spec.rb` to pass. Input the following 8 bears (you can make up details about them, but make gender either 'M' or 'F'):
 
 * Mr. Chocolate
 * Rowdy


### PR DESCRIPTION
I'm noticing students getting confused and/or looking up the solution branch because querying for 'male', or 'female' won't get the first test in `spec/select_spec.rb` to pass. Since the data in `lib/seed.sql` creates bears with either a 'M' or 'F' value for the gender attribute, I've edited the README to make that explicit.